### PR TITLE
Modify the path of "sifter-injector" in sifter.py

### DIFF
--- a/sifter.py
+++ b/sifter.py
@@ -33,7 +33,7 @@ try:
 except NameError:
     raw_input = input  # Python 3
 
-INJECTOR = ["/usr/bin/sifter-injector", "./sifter-injector"]
+INJECTOR = ["/usr/sbin/sifter-injector", "./sifter-injector"]
 arch = ""
 
 OUTPUT = "/tmp/sandsifter/data/"


### PR DESCRIPTION
Since we decide to place binaries in /sbin, the path of "sifter-injector" should be modified.